### PR TITLE
Allow the vizzini module to be installed side-by-side with cdc-acm.

### DIFF
--- a/99-vizzini.rules
+++ b/99-vizzini.rules
@@ -1,0 +1,1 @@
+SUBSYSTEM=="usb", ATTR{idVendor}=="04e2", RUN+="/bin/sh -c 'echo -n %k:1.0 >/sys/bus/usb/drivers/cdc_acm/unbind; echo -n %k:1.0 >/sys/bus/usb/drivers/vizzini/bind'"

--- a/Makefile
+++ b/Makefile
@@ -13,3 +13,8 @@ modules_install:
 
 clean:
 	rm -rf *.o *~ core .depend .*.cmd *.ko *.mod.c .tmp_versions vtty
+
+install-rules: 99-vizzini.rules
+	cp $< "/etc/udev/rules.d/99-vizzini.rules"
+	udevadm control --reload-rules
+	udevadm trigger --attr-match=idVendor=04e2 --verbose

--- a/README.Debian
+++ b/README.Debian
@@ -6,22 +6,15 @@ The original exar drivers were made for kernel 3.6 and lower.
 This package is intended for 3.7 and higher.
 
 Usage:
-Build the package to create the module-source package:
 
+# Build the vizzini-source package
 dpkg-buildpackage -rfakeroot
 
-Put that source package in your public repository.
+# Install the vizzini-source package
+sudo dpkg --install ../vizzini-source_*_all.deb
+sudo apt-get -f install
 
-To build a debian module for your kernel:
-
-dpkg -i <the source pacackage>
-
-cd <kernel_dir>
-tar xvjf /usr/src/vizzini.tar.bz2 -C ..
-export MODULE_LOC=$PWD/../modules
-fakeroot make-kpkg modules_image
-
-This will create a suitable vizzini-module package to suit your debian kernel
-package.
-
+# Use module assistant to build and install a package containing modules for
+# your current kernel.
+sudo m-a b-i vizzini
 

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+vizzini (1.0.0-3) unstable; urgency=low
+
+  * Now can be loaded side-by-side with the cdc-acm module.
+
+ -- Tim 'mithro' Ansell <mithro@mithis.com>  Thu, 02 Jul 2015 01:34:00 +1030
+
 vizzini (1.0.0-2) unstable; urgency=low
 
   * Now based on https://github.com/shenki/exar-uart-driver instead of https://github.com/ardje/vizzini

--- a/debian/rules
+++ b/debian/rules
@@ -27,6 +27,8 @@ binary-modules:
 	dh_installdocs
 	dh_installchangelogs
 	dh_installmodules
+	cp debian/vizzini.udev debian/$(PKGNAME).udev
+	dh_installudev --priority=99
 	dh_compress
 	dh_fixperms
 	dh_installdeb
@@ -50,6 +52,7 @@ install: build
 	dh_installdirs -p$(psource)  usr/src/modules/$(sname)/debian
 	cp Makefile README* vizzini.c vizzini.h vzioctl.h $(DESTDIR)
 	cp debian/*modules.in* debian/control debian/rules debian/changelog debian/copyright debian/compat $(DESTDIR)/debian
+	cp 99-vizzini.rules $(DESTDIR)/debian/vizzini.udev
 	cd debian/$(psource)/usr/src && tar c modules | bzip2 -9 > $(sname).tar.bz2 && rm -rf modules
 	dh_install
 

--- a/vizzini.c
+++ b/vizzini.c
@@ -1853,11 +1853,13 @@ static int __init xr21v141x_init(void)
 {
 	int retval;
 	xr21v141x_tty_driver = alloc_tty_driver(XR21V141X_TTY_MINORS);
-	if (!xr21v141x_tty_driver)
+	if (!xr21v141x_tty_driver) {
+		printk(KERN_INFO KBUILD_MODNAME ": alloc_tty_driver(%d) failed\n", XR21V141X_TTY_MINORS);
 		return -ENOMEM;
+        }
 	xr21v141x_tty_driver->driver_name = "vizzini",
-	xr21v141x_tty_driver->name = "ttyUSB",
-	xr21v141x_tty_driver->major = XR21V141X_TTY_MAJOR,
+	xr21v141x_tty_driver->name = "ttyVIZ",
+	xr21v141x_tty_driver->major = 0, // Dynamically allocate the major number
 	xr21v141x_tty_driver->minor_start = 0,
 	xr21v141x_tty_driver->type = TTY_DRIVER_TYPE_SERIAL,
 	xr21v141x_tty_driver->subtype = SERIAL_TYPE_NORMAL,
@@ -1869,12 +1871,14 @@ static int __init xr21v141x_init(void)
 
 	retval = tty_register_driver(xr21v141x_tty_driver);
 	if (retval) {
+		printk(KERN_INFO KBUILD_MODNAME ": tty_register_driver failed\n");
 		put_tty_driver(xr21v141x_tty_driver);
 		return retval;
 	}
 
 	retval = usb_register(&xr21v141x_driver);
 	if (retval) {
+		printk(KERN_INFO KBUILD_MODNAME ": usb_register failed\n");
 		tty_unregister_driver(xr21v141x_tty_driver);
 		put_tty_driver(xr21v141x_tty_driver);
 		return retval;
@@ -1898,4 +1902,3 @@ module_exit(xr21v141x_exit);
 MODULE_AUTHOR(DRIVER_AUTHOR);
 MODULE_DESCRIPTION(DRIVER_DESC);
 MODULE_LICENSE("GPL");
-MODULE_ALIAS_CHARDEV_MAJOR(ACM_TTY_MAJOR);

--- a/vizzini.c
+++ b/vizzini.c
@@ -1591,7 +1591,7 @@ skip_countries:
 	xr21v141x->ctrlurb->transfer_flags |= URB_NO_TRANSFER_DMA_MAP;
 	xr21v141x->ctrlurb->transfer_dma = xr21v141x->ctrl_dma;
 
-	dev_info(&intf->dev, "ttyUSB%d: XR21v14x usb uart device\n", minor);
+	dev_info(&intf->dev, "ttyVIZ%d: XR21v14x usb uart device\n", minor);
 
 	xr21v141x_set_control(xr21v141x, xr21v141x->ctrlout);
 

--- a/vizzini.h
+++ b/vizzini.h
@@ -195,7 +195,6 @@
  * Major and minor numbers.
  */
 
-#define XR21V141X_TTY_MAJOR		166
 #define XR21V141X_TTY_MINORS		32
 
 #define USB_RT_ACM		(USB_TYPE_CLASS | USB_RECIP_INTERFACE)


### PR DESCRIPTION
- Use a dynamically allocated major device number.
- Use the tty name of /dev/ttyVIZx so it doesn't conflict with other devices.
- Create a udev rule which makes sure the device is bound to the vizzini
  module. This is needed if the vizzini module is loaded _after_ the cdc-acm
  module as drivers are checked in the order they have been loaded and the
  cdc-acm registers for the device class exported by the device.
- Adding slightly better debug messages.
